### PR TITLE
feat: centos9 support

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -21,6 +21,9 @@ RUN git clone https://github.com/openstreetmap/osmdbt.git && \
     cmake .. && \
     cmake --build .
 
+RUN sed -i 's/^wal_level *= *hot_standby.*/wal_level = logical/' "${CONTAINER_SCRIPTS_PATH}/openshift-custom-postgresql-replication.conf.template"
+
 FROM quay.io/sclorg/postgresql-15-c9s
 
 COPY --from=base /app/osmdbt/postgresql-plugin/build/osm-logical.so /usr/lib64/pgsql/osm-logical.so
+COPY --from=base ${CONTAINER_SCRIPTS_PATH}/openshift-custom-postgresql-replication.conf.template ${CONTAINER_SCRIPTS_PATH}/openshift-custom-postgresql-replication.conf.template

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,3 +1,5 @@
+# Base image by https://github.com/sclorg/postgresql-container
+
 FROM quay.io/sclorg/postgresql-15-c9s as base
 
 WORKDIR /app

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,0 +1,26 @@
+FROM quay.io/sclorg/postgresql-15-c9s as base
+
+WORKDIR /app
+
+RUN source "${CONTAINER_SCRIPTS_PATH}/common.sh" && \ 
+    set_pgdata && \ 
+    initdb
+
+USER root
+
+RUN dnf update -y && \
+    dnf install -y git make cmake gcc gcc-c++ postgresql-server-devel redhat-rpm-config postgresql-contrib && \
+    dnf clean all
+
+# Clone the osmdbt repository
+RUN git clone https://github.com/openstreetmap/osmdbt.git && \
+    cd osmdbt && \
+    git checkout d3af909f3d81a57b98211f6600c49d7dcda8e2d7 && \
+    mkdir -p ./postgresql-plugin/build && \
+    cd ./postgresql-plugin/build && \
+    cmake .. && \
+    cmake --build .
+
+FROM quay.io/sclorg/postgresql-15-c9s
+
+COPY --from=base /app/osmdbt/postgresql-plugin/build/osm-logical.so /usr/lib64/pgsql/osm-logical.so


### PR DESCRIPTION
This PR is part of our POC to run PostgreSQL with osmdbt plugin compiled and installed on CentOS. 
 I've used [sclorg/postgresql-container](https://github.com/sclorg/postgresql-container) as a base image to avoid manual setup. They provide variety of base images for REHL/CentOS/Fedora opposed to Bitnami's images based on Debian/Ubuntu.

Related issue: MAPCO-6790